### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,37 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- lexer
-- remove combinators
-- items in mod
-- new syntax
-- parser generator
-- look ahead
-- make position opaque
-- left recursion
-- combinators
-- no need comma after block expression
-- more examples
-- backend
-- frontend
-- init
-
-### Fixed
-
-- left recursion
-- left recursion
-- choice
-
-### Other
-
-- add release workflow
-- update dependencies
-- doctest
-- document
-- format code
-- clean code
-- refactor arena
-- use typle
-- *(examples)* update bf example
-- *(docs)* update docs
-- update example
+- first release of the library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Wybxc/parse-it/releases/tag/parse-it-v0.1.0) - 2025-02-18
+
+### Added
+
+- lexer
+- remove combinators
+- items in mod
+- new syntax
+- parser generator
+- look ahead
+- make position opaque
+- left recursion
+- combinators
+- no need comma after block expression
+- more examples
+- backend
+- frontend
+- init
+
+### Fixed
+
+- left recursion
+- left recursion
+- choice
+
+### Other
+
+- add release workflow
+- update dependencies
+- doctest
+- document
+- format code
+- clean code
+- refactor arena
+- use typle
+- *(examples)* update bf example
+- *(docs)* update docs
+- update example


### PR DESCRIPTION



## 🤖 New release

* `parse-it`: 0.1.0
* `parse-it-macros`: 0.1.0
* `parse-it-codegen`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `parse-it`

<blockquote>

## [0.1.0](https://github.com/Wybxc/parse-it/releases/tag/parse-it-v0.1.0) - 2025-02-18

### Added

- lexer
- remove combinators
- items in mod
- new syntax
- parser generator
- look ahead
- make position opaque
- left recursion
- combinators
- no need comma after block expression
- more examples
- backend
- frontend
- init

### Fixed

- left recursion
- left recursion
- choice

### Other

- add release workflow
- update dependencies
- doctest
- document
- format code
- clean code
- refactor arena
- use typle
- *(examples)* update bf example
- *(docs)* update docs
- update example
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).