### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Wybxc/parse-it/compare/parse-it-v0.1.0...parse-it-v0.2.0) - 2025-07-14
+
+### Added
+
+- [**breaking**] remove logos feature
+- add debug support to parsing context and configuration
+- add Logos lexer support
+
+### Fixed
+
+- calc_logos example
+
+### Other
+
+- enhance stdin handling in Brainfuck example
+- use in-line format (suggested by clippy)
+- unify parsing method names and update documentation
+- simplify span handling in ParserState
+- refactor imports for consistency and readability
+- update parser and lexer to use mutable state references
+
 ## [0.1.0](https://github.com/Wybxc/parse-it/releases/tag/parse-it-v0.1.0) - 2025-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "parse-it"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "parse-it-macros",
  "rustc-hash",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "parse-it-codegen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hashlink",
  "proc-macro2",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "parse-it-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "parse-it-codegen",
  "proc-macro2",

--- a/parse-it-codegen/Cargo.toml
+++ b/parse-it-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parse-it-codegen"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A user-friendly, opinionated parser generator for Rust."

--- a/parse-it-macros/Cargo.toml
+++ b/parse-it-macros/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "parse-it-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A user-friendly, opinionated parser generator for Rust."
 
 [dependencies]
-parse-it-codegen = { version = "0.1.0", path = "../parse-it-codegen" }
+parse-it-codegen = { version = "0.2.0", path = "../parse-it-codegen" }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }

--- a/parse-it/Cargo.toml
+++ b/parse-it/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "parse-it"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A user-friendly, opinionated parser generator for Rust."
 license = "Apache-2.0"
 
 [dependencies]
-parse-it-macros = { version = "0.1.0", path = "../parse-it-macros" }
+parse-it-macros = { version = "0.1.1", path = "../parse-it-macros" }
 rustc-hash = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `parse-it-codegen`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `parse-it-macros`: 0.1.0 -> 0.1.1
* `parse-it`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `parse-it-codegen` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ParseItConfig.debug in /tmp/.tmpfGg8bL/parse-it/parse-it-codegen/src/syntax.rs:9

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Atom:PatTerminal in /tmp/.tmpfGg8bL/parse-it/parse-it-codegen/src/syntax.rs:277
```

### ⚠ `parse-it` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  parse_it::parser::ParserState::parse takes 1 generic types instead of 0, in /tmp/.tmpfGg8bL/parse-it/parse-it/src/parser.rs:146
  parse_it::ParserState::parse takes 1 generic types instead of 0, in /tmp/.tmpfGg8bL/parse-it/parse-it/src/parser.rs:146
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `parse-it`

<blockquote>

## [0.2.0](https://github.com/Wybxc/parse-it/compare/parse-it-v0.1.0...parse-it-v0.2.0) - 2025-07-14

### Added

- [**breaking**] remove logos feature
- add debug support to parsing context and configuration
- add Logos lexer support

### Fixed

- calc_logos example

### Other

- enhance stdin handling in Brainfuck example
- use in-line format (suggested by clippy)
- unify parsing method names and update documentation
- simplify span handling in ParserState
- refactor imports for consistency and readability
- update parser and lexer to use mutable state references
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).